### PR TITLE
Revert "Solve high CPU usage"

### DIFF
--- a/src/provider_sonar/provider_sonar_node.cc
+++ b/src/provider_sonar/provider_sonar_node.cc
@@ -102,7 +102,6 @@ void ProviderSonarNode::Spin() {
             static_cast<uint16_t>(config_.right_limit), config_.gain);
         previous = ros::Time::now();
       }
-        usleep(100);
     }
   }
 }


### PR DESCRIPTION
Reverts sonia-auv/provider_sonar#1
It is the good solution, but we'd rather use ros::Rate : http://wiki.ros.org/roscpp/Overview/Time
If you can change this, it will be merge back into the project :)

Thanks for the input!
